### PR TITLE
Add quantized export script and update LFW path

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,29 @@
       * `--resume:` path of saved model
       * `--feature_save_dir:` path to save the extracted features (must be .mat file)
 
+### Part 4: Quantization
+
+Two helper scripts are provided for converting the trained model to a fully
+quantized format.
+
+1. **export_quantized.py** – converts a training checkpoint to an int8 ONNX
+   model and a fully quantized TFLite model:
+
+   ```bash
+   python3 export_quantized.py --checkpoint path/to/checkpoint.pth \
+       --onnx_out mobilefacenet_int8.onnx --tflite_out mobilefacenet_int8.tflite
+   ```
+
+2. **quantize_onnx.py** – performs post training static quantization on an
+   existing FP32 ONNX model. Pass `--dataset` to provide a calibration dataset
+   (folder with sub‑directories for each class). If omitted, random data will be
+   used for calibration.
+
+   ```bash
+   python3 quantize_onnx.py --input mobilefacenet.onnx \
+       --dataset path/to/calibration_set --output mobilefacenet_int8.onnx
+   ```
+
 ## Results
 
   * You can just run the `lfw_eval.py` to get the result, the accuracy on LFW like this:

--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ quantized format.
        --dataset path/to/calibration_set --output mobilefacenet_int8.onnx
    ```
 
+3. **prepare_lfw_npz.py** – loads the bundled LFW sample images using
+   Keras and saves them as `lfw_test_data.npz`. This file can be used as
+   representative data when quantizing models.
+
+   ```bash
+   python3 prepare_lfw_npz.py
+   ```
+
 ## Results
 
   * You can just run the `lfw_eval.py` to get the result, the accuracy on LFW like this:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@
 
 ### Part 2: Train
 
-  1. Change the **CAISIA_DATA_DIR** and **LFW_DATA_DAR** in `config.py` to your data path.
+  1. Change the **CAISIA_DATA_DIR** and **LFW_DATA_DIR** in `config.py` to your data path if needed.
+     The repository now defaults `LFW_DATA_DIR` to `/data` so the evaluation
+     scripts can find the dataset mounted at that location.
   
   2. Train the mobilefacenet model. 
   

--- a/config.py
+++ b/config.py
@@ -9,7 +9,10 @@ MODEL_PRE = 'CASIA_B512_'
 
 
 CASIA_DATA_DIR = '/home/xiaocc/Documents/caffe_project/sphereface/train/data'
-LFW_DATA_DIR = '/home/xiaocc/Documents/caffe_project/sphereface/test/data'
+# Directory containing the LFW evaluation data. By default use the mounted
+# /data directory so the evaluation script can locate the dataset without
+# additional configuration.
+LFW_DATA_DIR = '/data'
 
 GPU = 0, 1
 

--- a/export_quantized.py
+++ b/export_quantized.py
@@ -1,0 +1,69 @@
+import argparse
+import os
+import numpy as np
+import torch
+from core import model
+from onnxruntime.quantization import quantize_dynamic, QuantType
+import onnx
+from onnx_tf.backend import prepare
+import tensorflow as tf
+import tempfile
+
+
+def load_model(ckpt_path):
+    net = model.MobileFacenet()
+    ckpt = torch.load(ckpt_path, map_location='cpu')
+    net.load_state_dict(ckpt['net_state_dict'])
+    net.eval()
+    return net
+
+
+def export_onnx(net, onnx_path):
+    dummy_input = torch.randn(1, 3, 112, 96)
+    torch.onnx.export(net, dummy_input, onnx_path,
+                      input_names=['input'], output_names=['embedding'],
+                      opset_version=11)
+
+
+def quantize_onnx(onnx_path, quant_path):
+    quantize_dynamic(onnx_path, quant_path, weight_type=QuantType.QInt8)
+
+
+def representative_data_gen():
+    for _ in range(100):
+        yield [np.random.rand(1, 112, 96, 3).astype(np.float32)]
+
+
+def export_tflite(quant_onnx_path, tflite_path):
+    onnx_model = onnx.load(quant_onnx_path)
+    tf_rep = prepare(onnx_model)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tf_rep.export_graph(tmpdir)
+        converter = tf.lite.TFLiteConverter.from_saved_model(tmpdir)
+        converter.optimizations = [tf.lite.Optimize.DEFAULT]
+        converter.representative_dataset = representative_data_gen
+        converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS_INT8]
+        converter.inference_input_type = tf.int8
+        converter.inference_output_type = tf.int8
+        tflite_model = converter.convert()
+        with open(tflite_path, 'wb') as f:
+            f.write(tflite_model)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Convert checkpoint to quantized models')
+    parser.add_argument('--checkpoint', required=True, help='Path to .ckpt file')
+    parser.add_argument('--onnx_out', default='mobilefacenet_int8.onnx', help='Output quantized onnx path')
+    parser.add_argument('--tflite_out', default='mobilefacenet_int8.tflite', help='Output quantized tflite path')
+    args = parser.parse_args()
+
+    net = load_model(args.checkpoint)
+    onnx_fp32 = 'temp_model.onnx'
+    export_onnx(net, onnx_fp32)
+    quantize_onnx(onnx_fp32, args.onnx_out)
+    export_tflite(args.onnx_out, args.tflite_out)
+    os.remove(onnx_fp32)
+
+
+if __name__ == '__main__':
+    main()

--- a/lfw_eval.py
+++ b/lfw_eval.py
@@ -14,30 +14,41 @@ from config import LFW_DATA_DIR
 import argparse
 
 def parseList(root):
-    with open(os.path.join(root, 'pairs.txt')) as f:
-        pairs = f.read().splitlines()[1:]
+    pairs_path = os.path.join(root, 'pairs.txt')
+    with open(pairs_path) as f:
+        pairs = f.read().splitlines()
+
+    # remove header if present
+    if pairs and pairs[0].lower().startswith('name'):
+        pairs = pairs[1:]
+
     folder_name = 'lfw-112X96'
+    if not os.path.isdir(os.path.join(root, folder_name)):
+        alt = os.path.join(root, 'lfw-deepfunneled', 'lfw-deepfunneled')
+        if os.path.isdir(alt):
+            folder_name = os.path.join('lfw-deepfunneled', 'lfw-deepfunneled')
+
     nameLs = []
     nameRs = []
     folds = []
     flags = []
     for i, p in enumerate(pairs):
-        p = p.split('\t')
+        p = p.replace(',', ' ').split()
+        if len(p) < 3:
+            continue
         if len(p) == 3:
-            nameL = os.path.join(root, folder_name, p[0], p[0] + '_' + '{:04}.jpg'.format(int(p[1])))
-            nameR = os.path.join(root, folder_name, p[0], p[0] + '_' + '{:04}.jpg'.format(int(p[2])))
-            fold = i // 600
+            nameL = os.path.join(root, folder_name, p[0], f'{p[0]}_{int(p[1]):04}.jpg')
+            nameR = os.path.join(root, folder_name, p[0], f'{p[0]}_{int(p[2]):04}.jpg')
             flag = 1
-        elif len(p) == 4:
-            nameL = os.path.join(root, folder_name, p[0], p[0] + '_' + '{:04}.jpg'.format(int(p[1])))
-            nameR = os.path.join(root, folder_name, p[2], p[2] + '_' + '{:04}.jpg'.format(int(p[3])))
-            fold = i // 600
+        else:
+            nameL = os.path.join(root, folder_name, p[0], f'{p[0]}_{int(p[1]):04}.jpg')
+            nameR = os.path.join(root, folder_name, p[2], f'{p[2]}_{int(p[3]):04}.jpg')
             flag = -1
+        fold = i // 600
         nameLs.append(nameL)
         nameRs.append(nameR)
         folds.append(fold)
         flags.append(flag)
-    # print(nameLs)
     return [nameLs, nameRs, folds, flags]
 
 

--- a/prepare_lfw_npz.py
+++ b/prepare_lfw_npz.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Prepare an NPZ file from the bundled LFW sample images.
+
+This script loads all images under `data/lfw-deepfunneled/lfw-deepfunneled`
+using Keras' ``ImageDataGenerator`` and saves them to ``lfw_test_data.npz``.
+"""
+
+import os
+import numpy as np
+from tensorflow.keras.preprocessing.image import ImageDataGenerator
+
+
+def main():
+    base_dir = os.path.join(os.path.dirname(__file__), 'data',
+                            'lfw-deepfunneled', 'lfw-deepfunneled')
+    nb_test_files = sum(len(files) for _, _, files in os.walk(base_dir))
+
+    datagen = ImageDataGenerator(rescale=1.0 / 255)
+    generator = datagen.flow_from_directory(
+        base_dir,
+        target_size=(224, 224),
+        batch_size=nb_test_files,
+        class_mode='categorical',
+        shuffle=False,
+    )
+    x_test, y_test = next(generator)
+    np.savez('lfw_test_data.npz', x_test=x_test, y_test=y_test)
+
+
+if __name__ == '__main__':
+    main()

--- a/quantize_onnx.py
+++ b/quantize_onnx.py
@@ -1,0 +1,129 @@
+import os
+import argparse
+import glob
+import random
+import shutil
+from datetime import datetime
+from typing import Optional, List, Dict
+
+import numpy as np
+import onnx
+import onnxruntime
+from onnxruntime import quantization
+from onnxruntime.quantization import CalibrationDataReader, CalibrationMethod, QuantFormat, QuantType, quantize_static
+from onnx import version_converter
+import tensorflow as tf
+from tqdm import tqdm
+
+
+def change_opset(input_model: str, new_opset: int = 15) -> str:
+    """Upgrade the ONNX opset of *input_model* in place."""
+    model = onnx.load(input_model)
+    current = model.opset_import[0].version
+    if current == new_opset:
+        return input_model
+    converted = version_converter.convert_version(model, new_opset)
+    tmp = input_model + '.tmp'
+    onnx.save(converted, tmp)
+    onnxruntime.InferenceSession(tmp)  # check
+    os.replace(tmp, input_model)
+    return input_model
+
+
+def create_calibration_dataset(dataset_path: str, samples_per_class: int = 100) -> str:
+    """Create a smaller dataset for calibration."""
+    target = os.path.join(os.path.dirname(dataset_path), 'calibration_' + os.path.basename(dataset_path))
+    if not os.path.exists(target):
+        os.makedirs(target)
+    for class_dir in tqdm(next(os.walk(dataset_path))[1]):
+        images = (glob.glob(os.path.join(dataset_path, class_dir, '*.jpg')) +
+                  glob.glob(os.path.join(dataset_path, class_dir, '*.png')) +
+                  glob.glob(os.path.join(dataset_path, class_dir, '*.jpeg')))
+        random.shuffle(images)
+        for img in images[:samples_per_class]:
+            shutil.copy2(img, target)
+    return target
+
+
+TORCH_MEANS = [0.485, 0.456, 0.406]
+TORCH_STD = [0.224, 0.224, 0.224]
+
+
+def preprocess_image_batch(folder: str, h: int, w: int, limit: int = 0) -> np.ndarray:
+    files = os.listdir(folder)
+    if limit > 0:
+        files = files[:limit]
+    batch = []
+    for f in files:
+        img_path = os.path.join(folder, f)
+        img = tf.keras.utils.load_img(img_path, color_mode='rgb', target_size=(w, h), interpolation='nearest')
+        arr = np.array([tf.keras.utils.img_to_array(img)])
+        arr = -1 + arr / 127.5
+        arr = arr.transpose((0, 3, 1, 2))
+        batch.append(arr)
+    return np.stack(batch, axis=0)
+
+
+def preprocess_random_images(h: int, w: int, c: int, count: int = 400) -> np.ndarray:
+    batch = []
+    for _ in range(count):
+        vals = np.random.uniform(0, 1, c*h*w).astype('float32')
+        batch.append(vals.reshape(1, c, h, w))
+    return np.concatenate(np.expand_dims(batch, axis=0), axis=0)
+
+
+class ImageNetDataReader(CalibrationDataReader):
+    def __init__(self, folder: Optional[str], model_path: str):
+        session = onnxruntime.InferenceSession(model_path, None)
+        (_, c, h, w) = session.get_inputs()[0].shape
+        if folder:
+            self.data = preprocess_image_batch(folder, h, w, limit=0)
+        else:
+            self.data = preprocess_random_images(h, w, c)
+        self.input_name = session.get_inputs()[0].name
+        self.enum_data = None
+
+    def get_next(self) -> Optional[Dict[str, List[float]]]:
+        if self.enum_data is None:
+            self.enum_data = iter([{self.input_name: d} for d in self.data])
+        return next(self.enum_data, None)
+
+    def rewind(self):
+        self.enum_data = None
+
+
+def quantize_model(input_model: str, dataset: Optional[str], output_model: str) -> None:
+    change_opset(input_model, 15)
+    if dataset:
+        calib_dataset = create_calibration_dataset(dataset, samples_per_class=200)
+    else:
+        calib_dataset = None
+    dr = ImageNetDataReader(calib_dataset, input_model)
+    infer_model = os.path.splitext(input_model)[0] + '_infer.onnx'
+    quantization.quant_pre_process(input_model_path=input_model, output_model_path=infer_model, skip_optimization=False)
+    quantize_static(
+        infer_model,
+        output_model,
+        dr,
+        calibrate_method=CalibrationMethod.MinMax,
+        quant_format=QuantFormat.QDQ,
+        per_channel=True,
+        weight_type=QuantType.QInt8,
+        activation_type=QuantType.QInt8,
+        reduce_range=True,
+        extra_options={'WeightSymmetric': True, 'ActivationSymmetric': False}
+    )
+    print(f'Quantized model saved to {output_model}')
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Static int8 quantization for ONNX models')
+    parser.add_argument('--input', required=True, help='Path to fp32 ONNX model')
+    parser.add_argument('--dataset', help='Path to dataset for calibration')
+    parser.add_argument('--output', default='model_int8.onnx', help='Output quantized model path')
+    args = parser.parse_args()
+    quantize_model(args.input, args.dataset, args.output)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- default `LFW_DATA_DIR` to `/data`
- update README instructions about the new default path
- add `export_quantized.py` to convert checkpoint to quantized ONNX and TFLite models

## Testing
- `python -m py_compile export_quantized.py`
- `python -m py_compile train.py lfw_eval.py`


------
https://chatgpt.com/codex/tasks/task_e_685ad3944db8832ea80029e8198f102b